### PR TITLE
Data accumulation hook for server-side rendering

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "scripts": {
     "start": "rimraf dist && rollup -c -w",
     "ci-cd": "echo 'CI-CD' && npm-run-all --silent clean --parallel ci-cd-*",
+    "ci-cd-audit": "npm audit",
+    "ci-cd-lint": "npm-run-all --silent lint",
     "ci-cd-test": "npm run test",
     "ci-cd-build": "npm run build",
     "clean": "echo 'CLEAN' && npm-run-all --silent --parallel clean-*",
@@ -22,8 +24,6 @@
     "clean-dist": "rimraf dist",
     "lint": "eslint src/**/*.js",
     "test": "echo 'TEST' && cross-env NODE_ENV=test npm-run-all --silent test-*",
-    "test-audit": "npm audit || echo '\\nnpm audit failures temporarily ignored!\\n'",
-    "test-lint": "npm-run-all --silent lint",
     "test-run": "cross-env NODE_ENV=development jest",
     "build": "echo 'BUILD' && npm-run-all --silent build-*",
     "build-rollup": "rollup -c",

--- a/src/render-to-html.js
+++ b/src/render-to-html.js
@@ -23,6 +23,7 @@ export default async function renderToHtml(
     {
         render = defaultRender,
         className,
+        onData,
     } = {}
 ) {
     const {__isomorphic_name__: name} = isomorphicElement.type;
@@ -94,7 +95,7 @@ export default async function renderToHtml(
     // Now that everything is resolved, synchronously render the html.
     const html = render((
         <IsomorphicContext.Provider value={SERVER}>
-            <ServerContext.Provider value={{getStream}}>
+            <ServerContext.Provider value={{getStream, onData}}>
                 {isomorphicElement}
             </ServerContext.Provider>
         </IsomorphicContext.Provider>

--- a/test/__snapshots__/render-to-html.test.js.snap
+++ b/test/__snapshots__/render-to-html.test.js.snap
@@ -155,6 +155,18 @@ exports[`renderToHtml(isomorphicComponent) <Connect /> styled nested isomorphic 
 </body>
 `;
 
+exports[`renderToHtml(isomorphicComponent) onData child overrides parent; last sibling wins accumulates the expected data 1`] = `
+Object {
+  "maxAge": 60,
+}
+`;
+
+exports[`renderToHtml(isomorphicComponent) onData parent overrides child; first sibling wins accumulates the expected data 1`] = `
+Object {
+  "maxAge": 30,
+}
+`;
+
 exports[`renderToHtml(isomorphicComponent) useIsomorphicContext() nested isomorphic component renders correctly 1`] = `
 <head></head>
 

--- a/test/data/iso-streams/nested.js
+++ b/test/data/iso-streams/nested.js
@@ -27,5 +27,8 @@ export default function getData(props, hydration) {
             v: v$,
             w: w$,
         },
+        data: {
+            maxAge: 30,
+        },
     });
 }

--- a/test/data/iso-streams/simple.js
+++ b/test/data/iso-streams/simple.js
@@ -19,5 +19,8 @@ export default function getData(props, hydration) {
         hydration: {
             baseValue: baseValue$,
         },
+        data: {
+            maxAge: 60,
+        },
     });
 }

--- a/test/render-to-html.test.js
+++ b/test/render-to-html.test.js
@@ -206,4 +206,50 @@ describe('renderToHtml(isomorphicComponent)', () => {
             expect(error).toBe('Nope!');
         });
     });
+
+    // Needs more tests
+    describe('onData', () => {
+        let accumulatedData = {};
+
+        afterEach(() => {
+            accumulatedData = {};
+        });
+
+        describe('child overrides parent; last sibling wins', () => {
+            beforeEach(() => {
+                return renderToHtml(
+                    <IsoNestedConnected coefficient={9} />,
+                    {
+                        onData(data) {
+                            Object.assign(accumulatedData, data);
+                        },
+                    }
+                );
+            });
+
+            test('accumulates the expected data', () => {
+                expect(accumulatedData).toMatchSnapshot();
+            });
+        });
+
+        describe('parent overrides child; first sibling wins', () => {
+            beforeEach(() => {
+                return renderToHtml(
+                    <IsoNestedConnected coefficient={9} />,
+                    {
+                        onData(data) {
+                            accumulatedData = {
+                                ...data,
+                                ...accumulatedData,
+                            };
+                        },
+                    }
+                );
+            });
+
+            test('accumulates the expected data', () => {
+                expect(accumulatedData).toMatchSnapshot();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Also

* Don't audit and lint when running tests locally
* Improve rendering phase detection in `isomorphic`
* Don't provide a hydration context for pure client-side rendering